### PR TITLE
feature/SCKT-4_Export_types_from_package_directly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { ApiKitClient } from './ApiKitClient';
+export * from './types';


### PR DESCRIPTION
📦  The goal of this ticket is to import the types like: `PaginatedResponse` inside the consumer app rather than creating identical one to match it...